### PR TITLE
注文管理画面のモーダル部分をコンポーネントとして分離

### DIFF
--- a/src/components/organisms/OrderModal/OrderModal.tsx
+++ b/src/components/organisms/OrderModal/OrderModal.tsx
@@ -1,0 +1,461 @@
+import React from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Drawer,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerCloseButton,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Alert,
+  AlertIcon,
+  VStack,
+  Box,
+  Text,
+  Badge,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Tooltip,
+  useToast,
+  Flex,
+} from '@chakra-ui/react';
+import { format } from 'date-fns';
+import { Order, OrderStatus, OrderItemField } from '@/types/order';
+import CommonButton from '@/components/atoms/CommonButton';
+import OrderForm from '@/components/organisms/OrderForm';
+
+interface OrderModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  isMobile: boolean;
+  modalSize?: string;
+  modalMode: 'detail' | 'add' | 'edit';
+  activeOrder: Order | null;
+  newOrder: any;
+  formErrors: any;
+  statusColorScheme: Record<OrderStatus, string>;
+  statusDisplayText: Record<OrderStatus, string>;
+  handleInputChange: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => void;
+  handleOrderItemChange: (
+    index: number,
+    field: OrderItemField,
+    value: string | number,
+  ) => void;
+  handleAddOrderItem: () => void;
+  handleRemoveOrderItem: (index: number) => void;
+  handleSubmit: () => void;
+}
+
+const OrderModal: React.FC<OrderModalProps> = ({
+  isOpen,
+  onClose,
+  isMobile,
+  modalSize,
+  modalMode,
+  activeOrder,
+  newOrder,
+  formErrors,
+  statusColorScheme,
+  statusDisplayText,
+  handleInputChange,
+  handleOrderItemChange,
+  handleAddOrderItem,
+  handleRemoveOrderItem,
+  handleSubmit,
+}) => {
+  const toast = useToast();
+
+  const renderOrderDetails = () => {
+    if (!activeOrder) {
+      return (
+        <Alert status="info">
+          <AlertIcon />
+          注文情報を読み込んでいます...
+        </Alert>
+      );
+    }
+
+    const items = activeOrder.order_items;
+
+    if (!items || items.length === 0) {
+      return (
+        <Alert status="warning">
+          <AlertIcon />
+          注文商品情報が見つかりません
+        </Alert>
+      );
+    }
+
+    const basicInfoItems = [
+      {
+        id: 'userName',
+        label: '担当者',
+        value: activeOrder.user?.username || '未割り当て',
+      },
+      { id: 'orderNumber', label: '注文番号', value: activeOrder.orderNumber },
+      {
+        id: 'productIds',
+        label: '商品ID',
+        value: (
+          <VStack
+            align="stretch"
+            spacing={2}
+            border="1px solid"
+            borderColor="gray.200"
+            borderRadius="md"
+            p={2}
+            maxH="100px"
+            overflowY="auto">
+            {items.map((item, index) => (
+              <Text key={`product-id-${item.id || index}`}>
+                {item.product.id}
+              </Text>
+            ))}
+          </VStack>
+        ),
+      },
+      {
+        id: 'orderDate',
+        label: '注文日時',
+        value:
+          activeOrder.orderDate &&
+          format(new Date(activeOrder.orderDate), 'yyyy/MM/dd HH:mm'),
+      },
+      {
+        id: 'totalAmount',
+        label: '合計金額',
+        value: `¥${activeOrder.totalAmount.toLocaleString()}`,
+      },
+      ...(activeOrder.discountApplied > 0
+        ? [
+            {
+              id: 'discount',
+              label: '適用割引',
+              value: `¥${activeOrder.discountApplied.toLocaleString()}`,
+            },
+          ]
+        : []),
+    ];
+
+    return (
+      <VStack align="stretch" spacing={6} py={2}>
+        <Box
+          borderWidth="1px"
+          borderRadius="lg"
+          p={4}
+          maxH="300px"
+          overflowY="auto">
+          <VStack align="stretch" spacing={4}>
+            <Flex justifyContent="space-between" alignItems="center">
+              <Text fontWeight="bold" fontSize="lg">
+                基本情報
+              </Text>
+              <Badge colorScheme={statusColorScheme[activeOrder.status]}>
+                {statusDisplayText[activeOrder.status]}
+              </Badge>
+            </Flex>
+            {basicInfoItems.map(item => (
+              <Box key={`basicInfo-${item.id}`}>
+                <Text fontWeight="semibold">{item.label}</Text>
+                {typeof item.value === 'string' ? (
+                  <Text>{item.value}</Text>
+                ) : (
+                  item.value
+                )}
+              </Box>
+            ))}
+          </VStack>
+        </Box>
+
+        <Box
+          borderWidth="1px"
+          borderRadius="lg"
+          p={4}
+          overflowX="auto"
+          maxHeight="300px"
+          overflowY="auto">
+          <Text fontWeight="bold" fontSize="lg" mb={4}>
+            注文商品
+          </Text>
+          <Box overflowX="auto">
+            <Table variant="simple" size="sm">
+              <Thead>
+                <Tr>
+                  <Th width="40%" whiteSpace="nowrap">
+                    商品名
+                  </Th>
+                  <Th width="20%" whiteSpace="nowrap" textAlign="center">
+                    数量
+                  </Th>
+                  <Th width="20%" whiteSpace="nowrap" textAlign="right">
+                    単価
+                  </Th>
+                  <Th width="20%" whiteSpace="nowrap" textAlign="right">
+                    小計
+                  </Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {items.map((item, index) => (
+                  <Tr key={`detail-order-item-${item.id || index}`}>
+                    <Td
+                      width="40%"
+                      sx={{
+                        maxWidth: '200px',
+                        cursor: 'pointer',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                      onClick={() => {
+                        if (isMobile) {
+                          toast({
+                            title: '商品名',
+                            description: item.product.name,
+                            status: 'info',
+                            duration: 3000,
+                            isClosable: true,
+                            position: 'top',
+                          });
+                        }
+                      }}>
+                      {isMobile ? (
+                        <Text
+                          sx={{
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            width: '100%',
+                          }}>
+                          {item.product.name}
+                        </Text>
+                      ) : (
+                        <Tooltip
+                          label={item.product.name}
+                          placement="top-start"
+                          hasArrow
+                          bg="gray.900"
+                          color="white">
+                          <Text
+                            whiteSpace="nowrap"
+                            overflow="hidden"
+                            textOverflow="ellipsis">
+                            {item.product.name}
+                          </Text>
+                        </Tooltip>
+                      )}
+                    </Td>
+                    <Td width="20%" textAlign="center" whiteSpace="nowrap">
+                      {item.quantity}
+                    </Td>
+                    <Td width="20%" textAlign="right" whiteSpace="nowrap">
+                      ¥{item.unitPrice.toLocaleString()}
+                    </Td>
+                    <Td width="20%" textAlign="right" whiteSpace="nowrap">
+                      ¥{(item.quantity * item.unitPrice).toLocaleString()}
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </Box>
+        </Box>
+      </VStack>
+    );
+  };
+
+  const renderCustomerInfo = () => {
+    if (!activeOrder?.customer) {
+      return (
+        <Alert status="info">
+          <AlertIcon />
+          顧客情報が見つかりません
+        </Alert>
+      );
+    }
+
+    const customerInfoItems = [
+      { id: 'customerId', label: '顧客ID', value: activeOrder.customer.id },
+      { id: 'name', label: '名前', value: activeOrder.customer.name },
+      {
+        id: 'email',
+        label: 'メールアドレス',
+        value: activeOrder.customer.email,
+      },
+      {
+        id: 'phone',
+        label: '電話番号',
+        value: activeOrder.customer.phoneNumber,
+      },
+      { id: 'address', label: '住所', value: activeOrder.customer.address },
+    ];
+
+    return (
+      <VStack align="stretch" spacing={4} py={2}>
+        <Box borderWidth="1px" borderRadius="lg" p={4}>
+          <VStack align="stretch" spacing={4}>
+            <Text fontWeight="bold" fontSize="lg">
+              顧客情報
+            </Text>
+            {customerInfoItems.map(item => (
+              <Box key={`customerInfo-${item.id}`}>
+                <Text fontWeight="semibold">{item.label}</Text>
+                <Text>{item.value}</Text>
+              </Box>
+            ))}
+          </VStack>
+        </Box>
+      </VStack>
+    );
+  };
+
+  const renderShipmentInfo = () => {
+    return (
+      <Alert status="info" mt={4}>
+        <AlertIcon />
+        配送情報は実装予定です
+      </Alert>
+    );
+  };
+
+  const ModalComponent = isMobile ? Drawer : Modal;
+  const modalProps = isMobile
+    ? {
+        isOpen,
+        onClose,
+        placement: 'right' as const,
+        size: 'full' as const,
+      }
+    : {
+        isOpen,
+        onClose,
+        size: modalSize,
+      };
+
+  return (
+    <ModalComponent {...modalProps}>
+      {isMobile ? <DrawerOverlay /> : <ModalOverlay />}
+      {isMobile ? (
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>
+            {modalMode === 'detail'
+              ? '注文詳細'
+              : modalMode === 'add'
+                ? '新規注文作成'
+                : '注文編集'}
+          </DrawerHeader>
+          <DrawerBody>
+            <Tabs isLazy>
+              <TabList>
+                <Tab>注文情報</Tab>
+                <Tab>顧客情報</Tab>
+                <Tab>配送情報</Tab>
+              </TabList>
+              <TabPanels>
+                <TabPanel>
+                  {modalMode === 'detail' ? (
+                    renderOrderDetails()
+                  ) : (
+                    <OrderForm
+                      newOrder={newOrder}
+                      formErrors={formErrors}
+                      modalMode={modalMode}
+                      statusDisplayText={statusDisplayText}
+                      handleInputChange={handleInputChange}
+                      handleOrderItemChange={handleOrderItemChange}
+                      handleAddOrderItem={handleAddOrderItem}
+                      handleRemoveOrderItem={handleRemoveOrderItem}
+                    />
+                  )}
+                </TabPanel>
+                <TabPanel>{renderCustomerInfo()}</TabPanel>
+                <TabPanel>{renderShipmentInfo()}</TabPanel>
+              </TabPanels>
+            </Tabs>
+          </DrawerBody>
+          <DrawerFooter>
+            {modalMode !== 'detail' && (
+              <CommonButton variant="primary" mr={3} onClick={handleSubmit}>
+                {modalMode === 'add' ? '作成' : '更新'}
+              </CommonButton>
+            )}
+            <CommonButton variant="ghost" onClick={onClose}>
+              閉じる
+            </CommonButton>
+          </DrawerFooter>
+        </DrawerContent>
+      ) : (
+        <ModalContent>
+          <ModalCloseButton />
+          <ModalHeader>
+            {modalMode === 'detail'
+              ? '注文詳細'
+              : modalMode === 'add'
+                ? '新規注文作成'
+                : '注文編集'}
+          </ModalHeader>
+          <ModalBody>
+            <Tabs isLazy>
+              <TabList>
+                <Tab>注文情報</Tab>
+                <Tab>顧客情報</Tab>
+                <Tab>配送情報</Tab>
+              </TabList>
+              <TabPanels>
+                <TabPanel>
+                  {modalMode === 'detail' ? (
+                    renderOrderDetails()
+                  ) : (
+                    <OrderForm
+                      newOrder={newOrder}
+                      formErrors={formErrors}
+                      modalMode={modalMode}
+                      statusDisplayText={statusDisplayText}
+                      handleInputChange={handleInputChange}
+                      handleOrderItemChange={handleOrderItemChange}
+                      handleAddOrderItem={handleAddOrderItem}
+                      handleRemoveOrderItem={handleRemoveOrderItem}
+                    />
+                  )}
+                </TabPanel>
+                <TabPanel>{renderCustomerInfo()}</TabPanel>
+                <TabPanel>{renderShipmentInfo()}</TabPanel>
+              </TabPanels>
+            </Tabs>
+          </ModalBody>
+          <ModalFooter>
+            {modalMode !== 'detail' && (
+              <CommonButton variant="primary" mr={3} onClick={handleSubmit}>
+                {modalMode === 'add' ? '作成' : '更新'}
+              </CommonButton>
+            )}
+            <CommonButton variant="ghost" onClick={onClose}>
+              閉じる
+            </CommonButton>
+          </ModalFooter>
+        </ModalContent>
+      )}
+    </ModalComponent>
+  );
+};
+
+export default OrderModal;

--- a/src/components/organisms/OrderModal/_tests_/OrderModal.test.tsx
+++ b/src/components/organisms/OrderModal/_tests_/OrderModal.test.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OrderModal from '../OrderModal';
+import { ChakraProvider } from '@chakra-ui/react';
+import { Order, OrderStatus, OrderForm, OrderItem } from '@/types/order';
+import { Product } from '@/types/product';
+import { Customer } from '@/types/customer';
+import { User } from '@/types/user';
+
+import '@testing-library/jest-dom';
+
+const mockOrderItem: OrderItem = {
+  id: '1',
+  orderId: 'ORD-2024-001',
+  productId: 'PROD-001',
+  quantity: 2,
+  unitPrice: 5000,
+  product: {
+    id: 'PROD-001',
+    name: 'テスト商品1',
+    price: 5000,
+    description: 'テスト商品1の説明',
+    stockQuantity: 100,
+    category: 'テストカテゴリ',
+    is_active: true,
+    created_at: '2024-04-01T10:00:00Z',
+    updated_at: '2024-04-01T10:00:00Z',
+  },
+  created_at: '2024-04-01T10:00:00Z',
+  updated_at: '2024-04-01T10:00:00Z',
+  deleted_at: null,
+};
+
+const mockActiveOrder: Order = {
+  id: '1',
+  orderNumber: 'ORD-2024-001',
+  orderDate: '2024-04-01T10:00:00Z',
+  totalAmount: 15000,
+  status: 'PENDING',
+  discountApplied: 1000,
+  customerId: 'CUST-001',
+  userId: 'USER-001',
+  campaignId: null,
+  customer: {
+    id: 'CUST-001',
+    name: 'テスト顧客',
+    email: 'test@example.com',
+    phoneNumber: '090-1234-5678',
+    address: '東京都渋谷区',
+    birthDate: '1990-01-01',
+    created_at: '2024-04-01T10:00:00Z',
+    updated_at: '2024-04-01T10:00:00Z',
+  },
+  user: {
+    id: 'USER-001',
+    username: 'テストユーザー',
+    email: 'user@example.com',
+    role: 'ADMIN',
+    isActive: true,
+    createdAt: '2024-04-01T10:00:00Z',
+    updatedAt: '2024-04-01T10:00:00Z',
+  },
+  order_items: [mockOrderItem],
+  created_at: '2024-04-01T10:00:00Z',
+  updated_at: '2024-04-01T10:00:00Z',
+  deleted_at: null,
+};
+
+const mockNewOrder: OrderForm = {
+  customerId: '',
+  orderItems: [],
+  status: 'PENDING',
+};
+
+const mockEditOrder: OrderForm = {
+  customerId: 'CUST-001',
+  orderItems: [
+    {
+      productId: 'PROD-001',
+      quantity: 2,
+    },
+  ],
+  status: 'PENDING',
+};
+
+const mockStatusColorScheme: Record<OrderStatus, string> = {
+  PENDING: 'yellow',
+  PROCESSING: 'blue',
+  CONFIRMED: 'purple',
+  SHIPPED: 'cyan',
+  DELIVERED: 'green',
+  CANCELLED: 'red',
+};
+
+const mockStatusDisplayText: Record<OrderStatus, string> = {
+  PENDING: '保留中',
+  PROCESSING: '処理中',
+  CONFIRMED: '確認済',
+  SHIPPED: '発送済',
+  DELIVERED: '配達完了',
+  CANCELLED: 'キャンセル済',
+};
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  isMobile: false,
+  modalSize: '4xl',
+  modalMode: 'detail' as const,
+  activeOrder: mockActiveOrder,
+  newOrder: mockNewOrder,
+  formErrors: {},
+  statusColorScheme: mockStatusColorScheme,
+  statusDisplayText: mockStatusDisplayText,
+  handleInputChange: jest.fn(),
+  handleOrderItemChange: jest.fn(),
+  handleAddOrderItem: jest.fn(),
+  handleRemoveOrderItem: jest.fn(),
+  handleSubmit: jest.fn(),
+};
+
+const renderWithChakra = (ui: React.ReactElement) => {
+  return render(<ChakraProvider>{ui}</ChakraProvider>);
+};
+
+describe('OrderModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('注文詳細モードで正しく表示される', () => {
+    renderWithChakra(<OrderModal {...defaultProps} />);
+    expect(screen.getByText('注文詳細')).toBeInTheDocument();
+    expect(screen.getByText('基本情報')).toBeInTheDocument();
+    expect(screen.getByText('注文商品')).toBeInTheDocument();
+  });
+
+  it('新規注文作成モードで正しく表示される', () => {
+    renderWithChakra(
+      <OrderModal
+        {...defaultProps}
+        modalMode="add"
+        activeOrder={null}
+        newOrder={mockNewOrder}
+      />,
+    );
+    expect(screen.getByText('新規注文作成')).toBeInTheDocument();
+  });
+
+  it('注文編集モードで正しく表示される', () => {
+    renderWithChakra(
+      <OrderModal
+        {...defaultProps}
+        modalMode="edit"
+        newOrder={mockEditOrder}
+      />,
+    );
+    expect(screen.getByText('注文編集')).toBeInTheDocument();
+  });
+
+  it('タブが正しく切り替わる', async () => {
+    renderWithChakra(<OrderModal {...defaultProps} />);
+    const customerInfoTab = screen.getByText('顧客情報');
+    fireEvent.click(customerInfoTab);
+    expect(screen.getByText('テスト顧客')).toBeInTheDocument();
+  });
+
+  it('配送情報タブに実装予定の表示がある', () => {
+    renderWithChakra(<OrderModal {...defaultProps} />);
+    const shipmentInfoTab = screen.getByText('配送情報');
+    fireEvent.click(shipmentInfoTab);
+    expect(screen.getByText('配送情報は実装予定です')).toBeInTheDocument();
+  });
+
+  it('activeOrderがnullの場合、ローディングメッセージが表示される', () => {
+    renderWithChakra(<OrderModal {...defaultProps} activeOrder={null} />);
+    expect(
+      screen.getByText('注文情報を読み込んでいます...'),
+    ).toBeInTheDocument();
+  });
+
+  it('注文商品が空の場合、適切なメッセージが表示される', () => {
+    const orderWithNoItems = {
+      ...mockActiveOrder,
+      order_items: [],
+    };
+    renderWithChakra(
+      <OrderModal {...defaultProps} activeOrder={orderWithNoItems} />,
+    );
+    expect(
+      screen.getByText('注文商品情報が見つかりません'),
+    ).toBeInTheDocument();
+  });
+
+  it('閉じるボタンをクリックするとonCloseが呼ばれる', () => {
+    renderWithChakra(<OrderModal {...defaultProps} />);
+    const closeButton = screen.getByText('閉じる');
+    fireEvent.click(closeButton);
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe('モバイル表示', () => {
+    it('モバイルモードで正しくDrawerとして表示される', () => {
+      renderWithChakra(<OrderModal {...defaultProps} isMobile={true} />);
+      expect(screen.getByRole('dialog')).toHaveClass('chakra-modal__content');
+    });
+
+    it('モバイルモードで商品名をクリックするとtoastが表示される', async () => {
+      renderWithChakra(<OrderModal {...defaultProps} isMobile={true} />);
+      const productName = screen.getByText('テスト商品1');
+      fireEvent.click(productName);
+    });
+  });
+});

--- a/src/components/templates/OrderManagementTemplate.tsx
+++ b/src/components/templates/OrderManagementTemplate.tsx
@@ -2,17 +2,9 @@
 
 import React from 'react';
 import {
-  Box,
   Flex,
-  Table,
-  Thead,
-  Tbody,
-  Tr,
-  Th,
-  Td,
   VStack,
   HStack,
-  Badge,
   Text,
   Modal,
   ModalOverlay,
@@ -21,33 +13,15 @@ import {
   ModalFooter,
   ModalBody,
   ModalCloseButton,
-  Tabs,
-  TabList,
-  TabPanels,
-  Tab,
-  TabPanel,
   Alert,
   AlertIcon,
   Spinner,
   Container,
-  Drawer,
-  DrawerBody,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerOverlay,
-  DrawerContent,
-  DrawerCloseButton,
   useBreakpointValue,
   useToast,
-  DrawerProps,
-  ModalProps,
   Stack,
-  Tooltip,
 } from '@chakra-ui/react';
 import { AddIcon, WarningIcon } from '@chakra-ui/icons';
-import { format } from 'date-fns';
-import { ja } from 'date-fns/locale';
-import { useOrderManagement } from '@/hooks/useOrderManagement';
 import { OrderStatus } from '@/types/order';
 import { useDisclosure } from '@chakra-ui/react';
 import DateRangePickerModal from '@/components/molecules/DateRangePickerModal/DateRangePickerModal';
@@ -57,11 +31,11 @@ import CommonButton from '@/components/atoms/CommonButton';
 import PageHeader from '@/components/molecules/PageHeader';
 import { OrderSearchFilter } from '@/components/molecules/OrderSearchFilter';
 import OrderTable from '@/components/organisms/OrderTable';
+import OrderModal from '@/components/organisms/OrderModal/OrderModal';
 import { formatDate } from '@/utils/dateFormatter';
-import OrderForm from '@/components/organisms/OrderForm';
+import { useOrderManagement } from '@/hooks/useOrderManagement';
 
-const OrdersPage = () => {
-  const toast = useToast();
+const OrderManagementTemplate = () => {
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
   const modalSize = useBreakpointValue({ base: 'full', md: '4xl' });
 
@@ -125,305 +99,6 @@ const OrdersPage = () => {
     DELIVERED: '配達完了',
     CANCELLED: 'キャンセル済',
   } as const;
-
-  type ModalComponentProps = {
-    isOpen: boolean;
-    onClose: () => void;
-  } & (
-    | {
-        placement: DrawerProps['placement'];
-        size: DrawerProps['size'];
-      }
-    | {
-        size: ModalProps['size'];
-      }
-  );
-
-  const ModalComponent = isMobile ? Drawer : Modal;
-  const ModalProps: ModalComponentProps = isMobile
-    ? {
-        isOpen,
-        onClose,
-        placement: 'right',
-        size: 'full',
-      }
-    : {
-        isOpen,
-        onClose,
-        size: modalSize,
-      };
-
-  const renderOrderForm = () => {
-    if (modalMode === 'add' || modalMode === 'edit') {
-      return (
-        <OrderForm
-          newOrder={newOrder}
-          formErrors={formErrors}
-          modalMode={modalMode}
-          statusDisplayText={statusDisplayText}
-          handleInputChange={handleInputChange}
-          handleOrderItemChange={handleOrderItemChange}
-          handleAddOrderItem={handleAddOrderItem}
-          handleRemoveOrderItem={handleRemoveOrderItem}
-        />
-      );
-    }
-
-    return null;
-  };
-
-  const renderOrderDetails = () => {
-    if (!activeOrder) {
-      return (
-        <Alert status="info">
-          <AlertIcon />
-          注文情報を読み込んでいます...
-        </Alert>
-      );
-    }
-
-    const items = activeOrder.order_items;
-
-    if (!items || items.length === 0) {
-      return (
-        <Alert status="warning">
-          <AlertIcon />
-          注文商品情報が見つかりません
-        </Alert>
-      );
-    }
-
-    const basicInfoItems = [
-      {
-        id: 'userName',
-        label: '担当者',
-        value: activeOrder.user?.username || '未割り当て',
-      },
-      { id: 'orderNumber', label: '注文番号', value: activeOrder.orderNumber },
-      {
-        id: 'productIds',
-        label: '商品ID',
-        value: (
-          <VStack
-            align="stretch"
-            spacing={2}
-            border="1px solid"
-            borderColor="gray.200"
-            borderRadius="md"
-            p={2}
-            maxH="100px"
-            overflowY="auto">
-            {items.map((item, index) => (
-              <Text key={`product-id-${item.id || index}`}>
-                {item.product.id}
-              </Text>
-            ))}
-          </VStack>
-        ),
-      },
-      {
-        id: 'orderDate',
-        label: '注文日時',
-        value:
-          activeOrder.orderDate &&
-          format(new Date(activeOrder.orderDate), 'yyyy/MM/dd HH:mm'),
-      },
-      {
-        id: 'totalAmount',
-        label: '合計金額',
-        value: `¥${activeOrder.totalAmount.toLocaleString()}`,
-      },
-      ...(activeOrder.discountApplied > 0
-        ? [
-            {
-              id: 'discount',
-              label: '適用割引',
-              value: `¥${activeOrder.discountApplied.toLocaleString()}`,
-            },
-          ]
-        : []),
-    ];
-
-    return (
-      <VStack align="stretch" spacing={6} py={2}>
-        <Box
-          borderWidth="1px"
-          borderRadius="lg"
-          p={4}
-          maxH="300px"
-          overflowY="auto">
-          <VStack align="stretch" spacing={4}>
-            <Flex justifyContent="space-between" alignItems="center">
-              <Text fontWeight="bold" fontSize="lg">
-                基本情報
-              </Text>
-              <Badge colorScheme={statusColorScheme[activeOrder.status]}>
-                {statusDisplayText[activeOrder.status]}
-              </Badge>
-            </Flex>
-            {basicInfoItems.map(item => (
-              <Box key={`basicInfo-${item.id}`}>
-                <Text fontWeight="semibold">{item.label}</Text>
-                {typeof item.value === 'string' ? (
-                  <Text>{item.value}</Text>
-                ) : (
-                  item.value
-                )}
-              </Box>
-            ))}
-          </VStack>
-        </Box>
-
-        <Box
-          borderWidth="1px"
-          borderRadius="lg"
-          p={4}
-          overflowX="auto"
-          maxHeight="300px"
-          overflowY="auto">
-          <Text fontWeight="bold" fontSize="lg" mb={4}>
-            注文商品
-          </Text>
-          <Box overflowX="auto">
-            <Table variant="simple" size="sm">
-              <Thead>
-                <Tr>
-                  <Th width="40%" whiteSpace="nowrap">
-                    商品名
-                  </Th>
-                  <Th width="20%" whiteSpace="nowrap" textAlign="center">
-                    数量
-                  </Th>
-                  <Th width="20%" whiteSpace="nowrap" textAlign="right">
-                    単価
-                  </Th>
-                  <Th width="20%" whiteSpace="nowrap" textAlign="right">
-                    小計
-                  </Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {items.map((item, index) => (
-                  <Tr key={`detail-order-item-${item.id || index}`}>
-                    <Td
-                      width="40%"
-                      sx={{
-                        maxWidth: '200px',
-                        cursor: 'pointer',
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                      }}
-                      onClick={() => {
-                        if (isMobile) {
-                          toast({
-                            title: '商品名',
-                            description: item.product.name,
-                            status: 'info',
-                            duration: 3000,
-                            isClosable: true,
-                            position: 'top',
-                          });
-                        }
-                      }}>
-                      {isMobile ? (
-                        <Text
-                          sx={{
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            width: '100%',
-                          }}>
-                          {item.product.name}
-                        </Text>
-                      ) : (
-                        <Tooltip
-                          label={item.product.name}
-                          placement="top-start"
-                          hasArrow
-                          bg="gray.900"
-                          color="white">
-                          <Text
-                            whiteSpace="nowrap"
-                            overflow="hidden"
-                            textOverflow="ellipsis">
-                            {item.product.name}
-                          </Text>
-                        </Tooltip>
-                      )}
-                    </Td>
-                    <Td width="20%" textAlign="center" whiteSpace="nowrap">
-                      {item.quantity}
-                    </Td>
-                    <Td width="20%" textAlign="right" whiteSpace="nowrap">
-                      ¥{item.unitPrice.toLocaleString()}
-                    </Td>
-                    <Td width="20%" textAlign="right" whiteSpace="nowrap">
-                      ¥{(item.quantity * item.unitPrice).toLocaleString()}
-                    </Td>
-                  </Tr>
-                ))}
-              </Tbody>
-            </Table>
-          </Box>
-        </Box>
-      </VStack>
-    );
-  };
-
-  const renderCustomerInfo = () => {
-    if (!activeOrder?.customer) {
-      return (
-        <Alert status="info">
-          <AlertIcon />
-          顧客情報が見つかりません
-        </Alert>
-      );
-    }
-
-    const customerInfoItems = [
-      { id: 'customerId', label: '顧客ID', value: activeOrder.customer.id },
-      { id: 'name', label: '名前', value: activeOrder.customer.name },
-      {
-        id: 'email',
-        label: 'メールアドレス',
-        value: activeOrder.customer.email,
-      },
-      {
-        id: 'phone',
-        label: '電話番号',
-        value: activeOrder.customer.phoneNumber,
-      },
-      { id: 'address', label: '住所', value: activeOrder.customer.address },
-    ];
-
-    return (
-      <VStack align="stretch" spacing={4} py={2}>
-        <Box borderWidth="1px" borderRadius="lg" p={4}>
-          <VStack align="stretch" spacing={4}>
-            <Text fontWeight="bold" fontSize="lg">
-              顧客情報
-            </Text>
-            {customerInfoItems.map(item => (
-              <Box key={`customerInfo-${item.id}`}>
-                <Text fontWeight="semibold">{item.label}</Text>
-                <Text>{item.value}</Text>
-              </Box>
-            ))}
-          </VStack>
-        </Box>
-      </VStack>
-    );
-  };
-
-  const renderShipmentInfo = () => {
-    return (
-      <Alert status="info" mt={4}>
-        <AlertIcon />
-        配送情報は実装予定です
-      </Alert>
-    );
-  };
 
   if (status === 'loading' && orders.length === 0) {
     return (
@@ -512,89 +187,23 @@ const OrdersPage = () => {
 
       <ScrollToTopButton />
 
-      <ModalComponent {...ModalProps}>
-        {isMobile && <DrawerOverlay />}
-        {!isMobile && <ModalOverlay />}
-        {isMobile ? (
-          <DrawerContent>
-            <DrawerCloseButton />
-            <DrawerHeader>
-              {modalMode === 'detail'
-                ? '注文詳細'
-                : modalMode === 'add'
-                  ? '新規注文作成'
-                  : '注文編集'}
-            </DrawerHeader>
-            <DrawerBody>
-              <Tabs isLazy>
-                <TabList>
-                  <Tab>注文情報</Tab>
-                  <Tab>顧客情報</Tab>
-                  <Tab>配送情報</Tab>
-                </TabList>
-                <TabPanels>
-                  <TabPanel>
-                    {modalMode === 'detail'
-                      ? renderOrderDetails()
-                      : renderOrderForm()}
-                  </TabPanel>
-                  <TabPanel>{renderCustomerInfo()}</TabPanel>
-                  <TabPanel>{renderShipmentInfo()}</TabPanel>
-                </TabPanels>
-              </Tabs>
-            </DrawerBody>
-            <DrawerFooter>
-              {modalMode !== 'detail' && (
-                <CommonButton variant="primary" mr={3} onClick={handleSubmit}>
-                  {modalMode === 'add' ? '作成' : '更新'}
-                </CommonButton>
-              )}
-              <CommonButton variant="ghost" onClick={onClose}>
-                閉じる
-              </CommonButton>
-            </DrawerFooter>
-          </DrawerContent>
-        ) : (
-          <ModalContent>
-            <ModalCloseButton />
-            <ModalHeader>
-              {modalMode === 'detail'
-                ? '注文詳細'
-                : modalMode === 'add'
-                  ? '新規注文作成'
-                  : '注文編集'}
-            </ModalHeader>
-            <ModalBody>
-              <Tabs isLazy>
-                <TabList>
-                  <Tab>注文情報</Tab>
-                  <Tab>顧客情報</Tab>
-                  <Tab>配送情報</Tab>
-                </TabList>
-                <TabPanels>
-                  <TabPanel>
-                    {modalMode === 'detail'
-                      ? renderOrderDetails()
-                      : renderOrderForm()}
-                  </TabPanel>
-                  <TabPanel>{renderCustomerInfo()}</TabPanel>
-                  <TabPanel>{renderShipmentInfo()}</TabPanel>
-                </TabPanels>
-              </Tabs>
-            </ModalBody>
-            <ModalFooter>
-              {modalMode !== 'detail' && (
-                <CommonButton variant="primary" mr={3} onClick={handleSubmit}>
-                  {modalMode === 'add' ? '作成' : '更新'}
-                </CommonButton>
-              )}
-              <CommonButton variant="ghost" onClick={onClose}>
-                閉じる
-              </CommonButton>
-            </ModalFooter>
-          </ModalContent>
-        )}
-      </ModalComponent>
+      <OrderModal
+        isOpen={isOpen}
+        onClose={onClose}
+        isMobile={isMobile}
+        modalSize={modalSize}
+        modalMode={modalMode}
+        activeOrder={activeOrder}
+        newOrder={newOrder}
+        formErrors={formErrors}
+        statusColorScheme={statusColorScheme}
+        statusDisplayText={statusDisplayText}
+        handleInputChange={handleInputChange}
+        handleOrderItemChange={handleOrderItemChange}
+        handleAddOrderItem={handleAddOrderItem}
+        handleRemoveOrderItem={handleRemoveOrderItem}
+        handleSubmit={handleSubmit}
+      />
 
       <Modal
         isOpen={isDeleteAlertOpen}
@@ -642,4 +251,4 @@ const OrdersPage = () => {
   );
 };
 
-export default OrdersPage;
+export default OrderManagementTemplate;

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -24,6 +24,8 @@ export interface OrderItem {
   deleted_at: string | null;
 }
 
+export type OrderItemField = keyof OrderFormItem;
+
 export interface FetchOrdersResponse {
   data: {
     data: Order[];


### PR DESCRIPTION
- OrderModalコンポーネントの新規作成
- OrderManagementTemplate.tsxからモーダル部分を削除
- モーダルの表示ロジックをOrderModalコンポーネントに移動
- OrderModalコンポーネントのテストケース追加
  - 表示モード（詳細/作成/編集）のテスト
  - タブ切り替えのテスト
  - データ不在時の表示確認テスト
  - モバイル表示のテスト