### PR TITLE
削除確認モーダルをコンポーネントとして分離

### DIFF
--- a/src/components/organisms/DeleteConfirmModal/DeleteConfirmModal.tsx
+++ b/src/components/organisms/DeleteConfirmModal/DeleteConfirmModal.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  VStack,
+  HStack,
+  Text,
+} from '@chakra-ui/react';
+import { WarningIcon } from '@chakra-ui/icons';
+import CommonButton from '@/components/atoms/CommonButton';
+
+interface DeleteConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  targetName: string;
+}
+
+const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  targetName,
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered size="sm">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{title}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <VStack spacing={4} align="stretch">
+            <HStack spacing={2}>
+              <WarningIcon color="red.500" />
+              <Text>この操作は取り消せません。</Text>
+            </HStack>
+            <Text>{targetName}を削除してもよろしいですか？</Text>
+          </VStack>
+        </ModalBody>
+        <ModalFooter>
+          <CommonButton variant="danger" mr={3} onClick={onConfirm}>
+            削除
+          </CommonButton>
+          <CommonButton variant="ghost" onClick={onClose}>
+            キャンセル
+          </CommonButton>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default DeleteConfirmModal;

--- a/src/components/organisms/DeleteConfirmModal/_tests_/DeleteConfirmModal.test.tsx
+++ b/src/components/organisms/DeleteConfirmModal/_tests_/DeleteConfirmModal.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DeleteConfirmModal from '../DeleteConfirmModal';
+import { ChakraProvider } from '@chakra-ui/react';
+import '@testing-library/jest-dom';
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  onConfirm: jest.fn(),
+  title: '注文の削除',
+  targetName: '注文番号: ORD-2024-001',
+};
+
+const renderWithChakra = (ui: React.ReactElement) => {
+  return render(<ChakraProvider>{ui}</ChakraProvider>);
+};
+
+describe('DeleteConfirmModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('モーダルが開いている時、指定されたタイトルが表示される', () => {
+    renderWithChakra(<DeleteConfirmModal {...defaultProps} />);
+    expect(screen.getByText('注文の削除')).toBeInTheDocument();
+  });
+
+  it('削除対象の名前が正しく表示される', () => {
+    renderWithChakra(<DeleteConfirmModal {...defaultProps} />);
+    expect(screen.getByText(/注文番号: ORD-2024-001/)).toBeInTheDocument();
+  });
+
+  it('警告メッセージが表示される', () => {
+    renderWithChakra(<DeleteConfirmModal {...defaultProps} />);
+    expect(screen.getByText('この操作は取り消せません。')).toBeInTheDocument();
+  });
+
+  it('削除ボタンをクリックするとonConfirmが呼ばれる', () => {
+    renderWithChakra(<DeleteConfirmModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('削除'));
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('キャンセルボタンをクリックするとonCloseが呼ばれる', () => {
+    renderWithChakra(<DeleteConfirmModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('モーダルが閉じている時、コンテンツが表示されない', () => {
+    renderWithChakra(<DeleteConfirmModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText('注文の削除')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/OrderModal/_tests_/OrderModal.test.tsx
+++ b/src/components/organisms/OrderModal/_tests_/OrderModal.test.tsx
@@ -3,9 +3,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import OrderModal from '../OrderModal';
 import { ChakraProvider } from '@chakra-ui/react';
 import { Order, OrderStatus, OrderForm, OrderItem } from '@/types/order';
-import { Product } from '@/types/product';
-import { Customer } from '@/types/customer';
-import { User } from '@/types/user';
 
 import '@testing-library/jest-dom';
 

--- a/src/components/templates/OrderManagementTemplate.tsx
+++ b/src/components/templates/OrderManagementTemplate.tsx
@@ -3,25 +3,15 @@
 import React from 'react';
 import {
   Flex,
-  VStack,
-  HStack,
   Text,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalFooter,
-  ModalBody,
-  ModalCloseButton,
   Alert,
   AlertIcon,
   Spinner,
   Container,
   useBreakpointValue,
-  useToast,
   Stack,
 } from '@chakra-ui/react';
-import { AddIcon, WarningIcon } from '@chakra-ui/icons';
+import { AddIcon } from '@chakra-ui/icons';
 import { OrderStatus } from '@/types/order';
 import { useDisclosure } from '@chakra-ui/react';
 import DateRangePickerModal from '@/components/molecules/DateRangePickerModal/DateRangePickerModal';
@@ -34,6 +24,7 @@ import OrderTable from '@/components/organisms/OrderTable';
 import OrderModal from '@/components/organisms/OrderModal/OrderModal';
 import { formatDate } from '@/utils/dateFormatter';
 import { useOrderManagement } from '@/hooks/useOrderManagement';
+import DeleteConfirmModal from '../organisms/DeleteConfirmModal/DeleteConfirmModal';
 
 const OrderManagementTemplate = () => {
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
@@ -205,37 +196,13 @@ const OrderManagementTemplate = () => {
         handleSubmit={handleSubmit}
       />
 
-      <Modal
+      <DeleteConfirmModal
         isOpen={isDeleteAlertOpen}
         onClose={cancelDelete}
-        isCentered
-        size="sm">
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>注文の削除</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            <VStack spacing={4} align="stretch">
-              <HStack spacing={2}>
-                <WarningIcon color="red.500" />
-                <Text>この操作は取り消せません。</Text>
-              </HStack>
-              <Text>
-                注文番号: {orderToDelete?.orderNumber}{' '}
-                を削除してもよろしいですか？
-              </Text>
-            </VStack>
-          </ModalBody>
-          <ModalFooter>
-            <CommonButton variant="danger" mr={3} onClick={confirmDelete}>
-              削除
-            </CommonButton>
-            <CommonButton variant="ghost" onClick={cancelDelete}>
-              キャンセル
-            </CommonButton>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+        onConfirm={confirmDelete}
+        title="注文の削除"
+        targetName={`注文番号: ${orderToDelete?.orderNumber}`}
+      />
 
       <DateRangePickerModal
         isOpen={isDatePickerOpen}


### PR DESCRIPTION
- DeleteConfirmModalコンポーネントの新規作成
- OrderManagementTemplate.tsxから削除確認モーダル部分を削除
- 削除確認モーダルの表示ロジックをDeleteConfirmModalコンポーネントに移動
- DeleteConfirmModalコンポーネントのテストケース追加
  - モーダルの表示/非表示のテスト
  - 警告メッセージの表示テスト
  - 削除・キャンセルボタンの動作テスト