### PR TITLE
OrderManagementTemplateコンポーネントの細分化

### DIFF
--- a/src/components/molecules/LoadingSpinner.tsx
+++ b/src/components/molecules/LoadingSpinner.tsx
@@ -1,0 +1,20 @@
+import { Flex, Spinner } from '@chakra-ui/react';
+import React from 'react';
+
+interface LoadingSpinnerProps {
+  hasMore?: boolean;
+  status: string;
+}
+
+export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
+  hasMore,
+  status,
+}) => {
+  if (!hasMore || status !== 'loading') return null;
+
+  return (
+    <Flex justify="center" my={4}>
+      <Spinner />
+    </Flex>
+  );
+};

--- a/src/components/molecules/ModalGroup.tsx
+++ b/src/components/molecules/ModalGroup.tsx
@@ -1,0 +1,113 @@
+import React, { ChangeEvent } from 'react';
+import { OrderItemField } from '@/types/order';
+import DateRangePickerModal from '@/components/molecules/DateRangePickerModal/DateRangePickerModal';
+import OrderModal from '@/components/organisms/OrderModal/OrderModal';
+import DeleteConfirmModal from '@/components/organisms/DeleteConfirmModal/DeleteConfirmModal';
+
+interface ModalGroupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  isDeleteAlertOpen: boolean;
+  isMobile: boolean;
+  modalSize: string | undefined;
+  modalMode: 'detail' | 'add' | 'edit';
+  activeOrder: any;
+  newOrder: any;
+  formErrors: any;
+  statusColorScheme: Record<string, string>;
+  statusDisplayText: Record<string, string>;
+  handleInputChange: (
+    e: ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => void;
+  handleOrderItemChange: (
+    index: number,
+    field: OrderItemField,
+    value: string | number,
+  ) => void;
+  handleAddOrderItem: () => void;
+  handleRemoveOrderItem: (index: number) => void;
+  handleSubmit: () => void;
+  cancelDelete: () => void;
+  confirmDelete: () => void;
+  orderToDelete: any;
+  isDatePickerOpen: boolean;
+  onDatePickerClose: () => void;
+  handleDateRangeFilter: (
+    range: 'custom' | 'today' | 'week' | 'month',
+    customStart?: Date | null,
+    customEnd?: Date | null,
+  ) => Promise<void>;
+  dateRange: {
+    start: Date | null;
+    end: Date | null;
+  };
+}
+
+export const ModalGroup: React.FC<ModalGroupProps> = ({
+  isOpen,
+  onClose,
+  isDeleteAlertOpen,
+  isMobile,
+  modalSize,
+  modalMode,
+  activeOrder,
+  newOrder,
+  formErrors,
+  statusColorScheme,
+  statusDisplayText,
+  handleInputChange,
+  handleOrderItemChange,
+  handleAddOrderItem,
+  handleRemoveOrderItem,
+  handleSubmit,
+  cancelDelete,
+  confirmDelete,
+  orderToDelete,
+  isDatePickerOpen,
+  onDatePickerClose,
+  handleDateRangeFilter,
+  dateRange,
+}) => {
+  return (
+    <>
+      <OrderModal
+        isOpen={isOpen}
+        onClose={onClose}
+        isMobile={isMobile}
+        modalSize={modalSize}
+        modalMode={modalMode}
+        activeOrder={activeOrder}
+        newOrder={newOrder}
+        formErrors={formErrors}
+        statusColorScheme={statusColorScheme}
+        statusDisplayText={statusDisplayText}
+        handleInputChange={handleInputChange}
+        handleOrderItemChange={handleOrderItemChange}
+        handleAddOrderItem={handleAddOrderItem}
+        handleRemoveOrderItem={handleRemoveOrderItem}
+        handleSubmit={handleSubmit}
+      />
+
+      <DeleteConfirmModal
+        isOpen={isDeleteAlertOpen}
+        onClose={cancelDelete}
+        onConfirm={confirmDelete}
+        title="注文の削除"
+        targetName={`注文番号: ${orderToDelete?.orderNumber}`}
+      />
+
+      <DateRangePickerModal
+        isOpen={isDatePickerOpen}
+        onClose={onDatePickerClose}
+        onApply={(start, end) => {
+          handleDateRangeFilter('custom', start, end);
+          onDatePickerClose();
+        }}
+        initialStartDate={dateRange.start}
+        initialEndDate={dateRange.end}
+      />
+    </>
+  );
+};
+
+export default ModalGroup;

--- a/src/components/molecules/OrderCountDisplay.tsx
+++ b/src/components/molecules/OrderCountDisplay.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Flex, Text } from '@chakra-ui/react';
+
+interface OrderCountDisplayProps {
+  totalCount: number;
+  currentCount: number;
+  showTotalCountOnly?: boolean;
+}
+
+export const OrderCountDisplay: React.FC<OrderCountDisplayProps> = ({
+  totalCount,
+  currentCount,
+  showTotalCountOnly = false,
+}) => {
+  if (showTotalCountOnly) {
+    return (
+      <Text mb={4} color="gray.600">
+        総注文リスト数: {totalCount.toLocaleString()}
+      </Text>
+    );
+  }
+
+  return (
+    <Flex justify="center" my={4}>
+      <Text color="red">
+        {currentCount >= totalCount
+          ? `全 ${totalCount.toLocaleString()} 件を表示中`
+          : `${currentCount.toLocaleString()} 件を表示中 (全 ${totalCount.toLocaleString()} 件)`}
+      </Text>
+    </Flex>
+  );
+};
+
+export default OrderCountDisplay;

--- a/src/components/molecules/OrderManagementHeader.tsx
+++ b/src/components/molecules/OrderManagementHeader.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PageHeader from './PageHeader';
+import { Stack } from '@chakra-ui/react';
+import CommonButton from '../atoms/CommonButton';
+import { AddIcon } from '@chakra-ui/icons';
+import BackToDashboardButton from '../atoms/BackToDashboardButton';
+
+interface OrderManagementHeaderProps {
+  onAddOrder: () => void;
+}
+
+export const OrderManagementHeader: React.FC<OrderManagementHeaderProps> = ({
+  onAddOrder,
+}) => {
+  return (
+    <PageHeader
+      title="注文管理"
+      buttons={
+        <Stack
+          direction={{ base: 'column', md: 'row' }}
+          spacing={2}
+          width={{ base: '100%', md: 'auto' }}>
+          <CommonButton
+            variant="primary"
+            withIcon={<AddIcon />}
+            onClick={onAddOrder}
+            isFullWidthMobile>
+            新規注文作成
+          </CommonButton>
+          <BackToDashboardButton />
+        </Stack>
+      }
+      mobileStack
+    />
+  );
+};

--- a/src/components/molecules/_tests_/ModalGroup.test.tsx
+++ b/src/components/molecules/_tests_/ModalGroup.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ModalGroup } from '../ModalGroup';
+import { ChakraProvider } from '@chakra-ui/react';
+
+jest.mock(
+  '@/components/molecules/DateRangePickerModal/DateRangePickerModal',
+  () => ({
+    __esModule: true,
+    default: ({
+      isOpen,
+      onApply,
+    }: {
+      isOpen: boolean;
+      onClose: () => void;
+      onApply: (start: Date | null, end: Date | null) => void;
+    }) =>
+      isOpen ? (
+        <div data-testid="date-range-picker-modal">
+          <button
+            onClick={() =>
+              onApply(new Date('2024-01-01'), new Date('2024-01-31'))
+            }
+            data-testid="apply-button">
+            Apply
+          </button>
+        </div>
+      ) : null,
+  }),
+);
+
+jest.mock('@/components/organisms/OrderModal/OrderModal', () => ({
+  __esModule: true,
+  default: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="order-modal">Order Modal</div> : null,
+}));
+
+jest.mock(
+  '@/components/organisms/DeleteConfirmModal/DeleteConfirmModal',
+  () => ({
+    __esModule: true,
+    default: ({
+      isOpen,
+      onConfirm,
+    }: {
+      isOpen: boolean;
+      onConfirm: () => void;
+    }) =>
+      isOpen ? (
+        <div data-testid="delete-confirm-modal" onClick={onConfirm}>
+          Delete Confirm Modal
+        </div>
+      ) : null,
+  }),
+);
+
+const renderWithChakra = (ui: React.ReactElement) => {
+  return render(<ChakraProvider>{ui}</ChakraProvider>);
+};
+
+describe('ModalGroup', () => {
+  const mockProps = {
+    isOpen: false,
+    onClose: jest.fn(),
+    isDeleteAlertOpen: false,
+    isMobile: false,
+    modalSize: 'md',
+    modalMode: 'detail' as const,
+    activeOrder: null,
+    newOrder: null,
+    formErrors: {},
+    statusColorScheme: {},
+    statusDisplayText: {},
+    handleInputChange: jest.fn(),
+    handleOrderItemChange: jest.fn(),
+    handleAddOrderItem: jest.fn(),
+    handleRemoveOrderItem: jest.fn(),
+    handleSubmit: jest.fn(),
+    cancelDelete: jest.fn(),
+    confirmDelete: jest.fn(),
+    orderToDelete: { orderNumber: 'TEST-001' },
+    isDatePickerOpen: false,
+    onDatePickerClose: jest.fn(),
+    handleDateRangeFilter: jest.fn(),
+    dateRange: {
+      start: null,
+      end: null,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('OrderModalが適切な状態で表示されること', () => {
+    renderWithChakra(<ModalGroup {...mockProps} isOpen={true} />);
+    expect(screen.getByTestId('order-modal')).toBeInTheDocument();
+  });
+
+  it('DeleteConfirmModalが適切な状態で表示されること', () => {
+    renderWithChakra(<ModalGroup {...mockProps} isDeleteAlertOpen={true} />);
+    expect(screen.getByTestId('delete-confirm-modal')).toBeInTheDocument();
+  });
+
+  it('DateRangePickerModalが適切な状態で表示されること', () => {
+    renderWithChakra(<ModalGroup {...mockProps} isDatePickerOpen={true} />);
+    expect(screen.getByTestId('date-range-picker-modal')).toBeInTheDocument();
+  });
+
+  it('削除確認モーダルでconfirmDelete関数が呼ばれること', () => {
+    renderWithChakra(<ModalGroup {...mockProps} isDeleteAlertOpen={true} />);
+    fireEvent.click(screen.getByTestId('delete-confirm-modal'));
+    expect(mockProps.confirmDelete).toHaveBeenCalled();
+  });
+
+  it('OrderModalが非表示の場合にレンダリングされないこと', () => {
+    renderWithChakra(<ModalGroup {...mockProps} isOpen={false} />);
+    expect(screen.queryByTestId('order-modal')).not.toBeInTheDocument();
+  });
+
+  it('DeleteConfirmModalが非表示の場合にレンダリングされないこと', () => {
+    renderWithChakra(<ModalGroup {...mockProps} isDeleteAlertOpen={false} />);
+    expect(
+      screen.queryByTestId('delete-confirm-modal'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('DateRangePickerModalが非表示の場合にレンダリングされないこと', () => {
+    renderWithChakra(<ModalGroup {...mockProps} isDatePickerOpen={false} />);
+    expect(
+      screen.queryByTestId('date-range-picker-modal'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('DateRangePickerModalでカスタム日付が選択された際に適切な関数が呼ばれること', () => {
+    renderWithChakra(<ModalGroup {...mockProps} isDatePickerOpen={true} />);
+
+    fireEvent.click(screen.getByTestId('apply-button'));
+
+    expect(mockProps.handleDateRangeFilter).toHaveBeenCalledWith(
+      'custom',
+      new Date('2024-01-01'),
+      new Date('2024-01-31'),
+    );
+    expect(mockProps.onDatePickerClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/organisms/_tests_/OrderTable.test.tsx
+++ b/src/components/organisms/_tests_/OrderTable.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import OrderTable from '../OrderTable';
+import { ChakraProvider } from '@chakra-ui/react';
+import { Order, OrderStatus, OrderItem } from '@/types/order';
+import { Customer } from '@/types/customer';
+
+const renderWithChakra = (ui: React.ReactElement) => {
+  return render(<ChakraProvider>{ui}</ChakraProvider>);
+};
+
+describe('OrderTable', () => {
+  const mockCustomer1: Customer = {
+    id: '1',
+    name: 'テスト顧客1',
+    email: 'test1@example.com',
+    phoneNumber: '090-1111-1111',
+    address: '東京都渋谷区1-1-1',
+    birthDate: '1990-01-01',
+    created_at: '2024-01-01',
+    updated_at: '2024-01-01',
+  };
+
+  const mockCustomer2: Customer = {
+    id: '2',
+    name: 'テスト顧客2',
+    email: 'test2@example.com',
+    phoneNumber: '090-2222-2222',
+    address: '東京都渋谷区2-2-2',
+    birthDate: '1990-01-01',
+    created_at: '2024-01-01',
+    updated_at: '2024-01-01',
+  };
+
+  const mockOrderItems: OrderItem[] = [
+    {
+      id: '1',
+      orderId: '1',
+      productId: '1',
+      quantity: 1,
+      unitPrice: 1000,
+      product: {
+        id: '1',
+        name: 'テスト商品1',
+        price: 1000,
+        description: 'テスト商品1の説明',
+        category: 'テストカテゴリー1',
+        stockQuantity: 10,
+        is_active: true,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        deleted_at: undefined,
+      },
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+      deleted_at: null,
+    },
+  ];
+
+  const mockOrders: Order[] = [
+    {
+      id: '1',
+      orderNumber: 'ORD-001',
+      orderDate: '2024-03-01',
+      totalAmount: 10000,
+      status: 'PENDING',
+      discountApplied: 0,
+      customerId: '1',
+      userId: '1',
+      campaignId: null,
+      customer: mockCustomer1,
+      order_items: mockOrderItems,
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+      deleted_at: null,
+    },
+    {
+      id: '2',
+      orderNumber: 'ORD-002',
+      orderDate: '2024-03-02',
+      totalAmount: 20000,
+      status: 'DELIVERED',
+      discountApplied: 0,
+      customerId: '2',
+      userId: '1',
+      campaignId: null,
+      customer: mockCustomer2,
+      order_items: mockOrderItems,
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+      deleted_at: null,
+    },
+  ];
+
+  const mockStatusColorScheme: Record<OrderStatus, string> = {
+    PENDING: 'yellow',
+    PROCESSING: 'blue',
+    CONFIRMED: 'purple',
+    SHIPPED: 'cyan',
+    DELIVERED: 'green',
+    CANCELLED: 'red',
+  };
+
+  const mockStatusDisplayText: Record<OrderStatus, string> = {
+    PENDING: '保留中',
+    PROCESSING: '処理中',
+    CONFIRMED: '確認済',
+    SHIPPED: '発送済',
+    DELIVERED: '配達完了',
+    CANCELLED: 'キャンセル済',
+  };
+
+  const mockProps = {
+    orders: mockOrders,
+    statusColorScheme: mockStatusColorScheme,
+    statusDisplayText: mockStatusDisplayText,
+    isMobile: false,
+    lastElementRef: jest.fn(),
+    handleOrderClick: jest.fn(),
+    handleEditOrder: jest.fn(),
+    handleDeleteOrder: jest.fn(),
+    formatDate: (date: string) => date,
+  };
+
+  it('テーブルヘッダーが正しく表示されること', () => {
+    renderWithChakra(<OrderTable {...mockProps} />);
+
+    expect(screen.getByText('注文番号')).toBeInTheDocument();
+    expect(screen.getByText('顧客名')).toBeInTheDocument();
+    expect(screen.getByText('注文日')).toBeInTheDocument();
+    expect(screen.getByText('合計金額')).toBeInTheDocument();
+    expect(screen.getByText('ステータス')).toBeInTheDocument();
+    expect(screen.getByText('アクション')).toBeInTheDocument();
+  });
+
+  it('注文データが正しくレンダリングされること', () => {
+    renderWithChakra(<OrderTable {...mockProps} />);
+
+    expect(screen.getByText('ORD-001')).toBeInTheDocument();
+    expect(screen.getByText('テスト顧客1')).toBeInTheDocument();
+    expect(screen.getByText('2024-03-01')).toBeInTheDocument();
+    expect(screen.getByText('¥10,000')).toBeInTheDocument();
+    expect(screen.getByText('保留中')).toBeInTheDocument();
+  });
+
+  it('PC表示時にボタンが正しく表示されること', () => {
+    renderWithChakra(<OrderTable {...mockProps} />);
+
+    expect(screen.getAllByText('詳細')).toHaveLength(2);
+    expect(screen.getAllByText('編集')).toHaveLength(2);
+    expect(screen.getAllByText('削除')).toHaveLength(2);
+  });
+
+  it('モバイル表示時にアイコンボタンが表示されること', () => {
+    renderWithChakra(<OrderTable {...{ ...mockProps, isMobile: true }} />);
+
+    expect(screen.getAllByLabelText('詳細を表示')).toHaveLength(2);
+    expect(screen.getAllByLabelText('注文を編集')).toHaveLength(2);
+    expect(screen.getAllByLabelText('注文を削除')).toHaveLength(2);
+  });
+
+  it('配達完了の注文は編集と削除が無効化されること', () => {
+    renderWithChakra(<OrderTable {...mockProps} />);
+
+    const editButtons = screen.getAllByText('編集');
+    const deleteButtons = screen.getAllByText('削除');
+
+    expect(editButtons[1]).toBeDisabled();
+    expect(deleteButtons[1]).toBeDisabled();
+  });
+
+  it('ボタンクリック時にハンドラーが呼び出されること', () => {
+    renderWithChakra(<OrderTable {...mockProps} />);
+
+    fireEvent.click(screen.getAllByText('詳細')[0]);
+    expect(mockProps.handleOrderClick).toHaveBeenCalledWith(mockOrders[0]);
+
+    fireEvent.click(screen.getAllByText('編集')[0]);
+    expect(mockProps.handleEditOrder).toHaveBeenCalledWith(mockOrders[0]);
+
+    fireEvent.click(screen.getAllByText('削除')[0]);
+    expect(mockProps.handleDeleteOrder).toHaveBeenCalledWith(mockOrders[0]);
+  });
+});

--- a/src/components/templates/OrderManagementTemplate.tsx
+++ b/src/components/templates/OrderManagementTemplate.tsx
@@ -3,28 +3,22 @@
 import React from 'react';
 import {
   Flex,
-  Text,
   Alert,
   AlertIcon,
   Spinner,
   Container,
   useBreakpointValue,
-  Stack,
 } from '@chakra-ui/react';
-import { AddIcon } from '@chakra-ui/icons';
-import { OrderStatus } from '@/types/order';
 import { useDisclosure } from '@chakra-ui/react';
-import DateRangePickerModal from '@/components/molecules/DateRangePickerModal/DateRangePickerModal';
-import BackToDashboardButton from '@/components/atoms/BackToDashboardButton';
-import ScrollToTopButton from '@/components/atoms/ScrollToTopButton';
-import CommonButton from '@/components/atoms/CommonButton';
-import PageHeader from '@/components/molecules/PageHeader';
-import { OrderSearchFilter } from '@/components/molecules/OrderSearchFilter';
-import OrderTable from '@/components/organisms/OrderTable';
-import OrderModal from '@/components/organisms/OrderModal/OrderModal';
-import { formatDate } from '@/utils/dateFormatter';
+import { OrderStatus } from '@/types/order';
 import { useOrderManagement } from '@/hooks/useOrderManagement';
-import DeleteConfirmModal from '../organisms/DeleteConfirmModal/DeleteConfirmModal';
+import { OrderManagementHeader } from '@/components/molecules/OrderManagementHeader';
+import { OrderSearchFilter } from '@/components/molecules/OrderSearchFilter';
+import { OrderCountDisplay } from '@/components/molecules/OrderCountDisplay';
+import { ModalGroup } from '@/components/molecules/ModalGroup';
+import ScrollToTopButton from '@/components/atoms/ScrollToTopButton';
+import { formatDate } from '@/utils/dateFormatter';
+import OrderTable from '../organisms/OrderTable';
 
 const OrderManagementTemplate = () => {
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
@@ -110,25 +104,7 @@ const OrderManagementTemplate = () => {
 
   return (
     <Container maxW="container.xl" py={5}>
-      <PageHeader
-        title="注文管理"
-        buttons={
-          <Stack
-            direction={{ base: 'column', md: 'row' }}
-            spacing={2}
-            width={{ base: '100%', md: 'auto' }}>
-            <CommonButton
-              variant="primary"
-              withIcon={<AddIcon />}
-              onClick={handleAddOrder}
-              isFullWidthMobile>
-              新規注文作成
-            </CommonButton>
-            <BackToDashboardButton />
-          </Stack>
-        }
-        mobileStack
-      />
+      <OrderManagementHeader onAddOrder={handleAddOrder} />
 
       <OrderSearchFilter
         searchTerm={searchTerm}
@@ -146,9 +122,11 @@ const OrderManagementTemplate = () => {
         clearFilters={clearFilters}
       />
 
-      <Text mb={4} color="gray.600">
-        総注文リスト数: {totalCount.toLocaleString()}
-      </Text>
+      <OrderCountDisplay
+        totalCount={totalCount}
+        currentCount={orders.length}
+        showTotalCountOnly={true}
+      />
 
       <OrderTable
         orders={orders}
@@ -162,13 +140,7 @@ const OrderManagementTemplate = () => {
         formatDate={formatDate}
       />
 
-      <Flex justify="center" my={4}>
-        <Text color="red">
-          {orders.length >= totalCount
-            ? `全 ${totalCount.toLocaleString()} 件を表示中`
-            : `${orders.length.toLocaleString()} 件を表示中 (全 ${totalCount.toLocaleString()} 件)`}
-        </Text>
-      </Flex>
+      <OrderCountDisplay totalCount={totalCount} currentCount={orders.length} />
 
       {hasMore && status === 'loading' && (
         <Flex justify="center" my={4}>
@@ -178,9 +150,10 @@ const OrderManagementTemplate = () => {
 
       <ScrollToTopButton />
 
-      <OrderModal
+      <ModalGroup
         isOpen={isOpen}
         onClose={onClose}
+        isDeleteAlertOpen={isDeleteAlertOpen}
         isMobile={isMobile}
         modalSize={modalSize}
         modalMode={modalMode}
@@ -194,25 +167,13 @@ const OrderManagementTemplate = () => {
         handleAddOrderItem={handleAddOrderItem}
         handleRemoveOrderItem={handleRemoveOrderItem}
         handleSubmit={handleSubmit}
-      />
-
-      <DeleteConfirmModal
-        isOpen={isDeleteAlertOpen}
-        onClose={cancelDelete}
-        onConfirm={confirmDelete}
-        title="注文の削除"
-        targetName={`注文番号: ${orderToDelete?.orderNumber}`}
-      />
-
-      <DateRangePickerModal
-        isOpen={isDatePickerOpen}
-        onClose={onDatePickerClose}
-        onApply={(start, end) => {
-          handleDateRangeFilter('custom', start, end);
-          onDatePickerClose();
-        }}
-        initialStartDate={dateRange.start}
-        initialEndDate={dateRange.end}
+        cancelDelete={cancelDelete}
+        confirmDelete={confirmDelete}
+        orderToDelete={orderToDelete}
+        isDatePickerOpen={isDatePickerOpen}
+        onDatePickerClose={onDatePickerClose}
+        handleDateRangeFilter={handleDateRangeFilter}
+        dateRange={dateRange}
       />
     </Container>
   );

--- a/src/components/templates/_tests_/OrderManagementTemplate.test.tsx
+++ b/src/components/templates/_tests_/OrderManagementTemplate.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import OrderManagementTemplate from '../OrderManagementTemplate';
+import { useOrderManagement } from '@/hooks/useOrderManagement';
+import { useBreakpointValue, useDisclosure } from '@chakra-ui/react';
+
+jest.mock('@/hooks/useOrderManagement');
+jest.mock('@chakra-ui/react', () => ({
+  ...jest.requireActual('@chakra-ui/react'),
+  useBreakpointValue: jest.fn(),
+  useDisclosure: jest.fn(),
+}));
+
+jest.mock('@/components/molecules/OrderManagementHeader', () => ({
+  OrderManagementHeader: () => (
+    <div data-testid="order-management-header">Header</div>
+  ),
+}));
+
+jest.mock('@/components/molecules/OrderSearchFilter', () => ({
+  OrderSearchFilter: () => (
+    <div data-testid="order-search-filter">Search Filter</div>
+  ),
+}));
+
+jest.mock('@/components/molecules/OrderCountDisplay', () => ({
+  OrderCountDisplay: ({
+    showTotalCountOnly,
+  }: {
+    showTotalCountOnly?: boolean;
+  }) => (
+    <div data-testid={showTotalCountOnly ? 'total-count' : 'current-count'}>
+      Count Display
+    </div>
+  ),
+}));
+
+jest.mock('@/components/organisms/OrderTable', () => ({
+  __esModule: true,
+  default: () => <div data-testid="order-table">Order Table</div>,
+}));
+
+jest.mock('@/components/molecules/ModalGroup', () => ({
+  ModalGroup: () => <div data-testid="modal-group">Modal Group</div>,
+}));
+
+jest.mock('@/components/atoms/ScrollToTopButton', () => ({
+  __esModule: true,
+  default: () => <div data-testid="scroll-to-top">Scroll To Top</div>,
+}));
+
+describe('OrderManagementTemplate', () => {
+  const defaultMockValues = {
+    orders: [],
+    totalCount: 0,
+    status: 'idle',
+    error: null,
+    isSearching: false,
+    hasMore: false,
+  };
+
+  beforeEach(() => {
+    (useOrderManagement as jest.Mock).mockReturnValue({
+      ...defaultMockValues,
+      handleAddOrder: jest.fn(),
+      handleEditOrder: jest.fn(),
+      handleDeleteOrder: jest.fn(),
+    });
+
+    (useBreakpointValue as jest.Mock).mockReturnValue(false);
+    (useDisclosure as jest.Mock).mockReturnValue({
+      isOpen: false,
+      onOpen: jest.fn(),
+      onClose: jest.fn(),
+    });
+  });
+
+  it('初期状態で全てのコンポーネントが正しくレンダリングされること', () => {
+    render(<OrderManagementTemplate />);
+
+    expect(screen.getByTestId('order-management-header')).toBeInTheDocument();
+    expect(screen.getByTestId('order-search-filter')).toBeInTheDocument();
+    expect(screen.getByTestId('total-count')).toBeInTheDocument();
+    expect(screen.getByTestId('order-table')).toBeInTheDocument();
+    expect(screen.getByTestId('current-count')).toBeInTheDocument();
+    expect(screen.getByTestId('scroll-to-top')).toBeInTheDocument();
+    expect(screen.getByTestId('modal-group')).toBeInTheDocument();
+  });
+
+  it('ローディング中は適切なスピナーが表示されること', () => {
+    (useOrderManagement as jest.Mock).mockReturnValue({
+      ...defaultMockValues,
+      status: 'loading',
+      orders: [],
+    });
+
+    render(<OrderManagementTemplate />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('エラー発生時にエラーアラートが表示されること', () => {
+    (useOrderManagement as jest.Mock).mockReturnValue({
+      ...defaultMockValues,
+      status: 'failed',
+      error: 'エラーが発生しました',
+    });
+
+    render(<OrderManagementTemplate />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+  });
+
+  it('無限スクロール時のローディングスピナーが適切に表示されること', () => {
+    (useOrderManagement as jest.Mock).mockReturnValue({
+      ...defaultMockValues,
+      hasMore: true,
+      status: 'loading',
+      orders: [{ id: 1 }],
+    });
+
+    render(<OrderManagementTemplate />);
+    const loadingTexts = screen.getAllByText('Loading...');
+    expect(loadingTexts).toHaveLength(1);
+  });
+
+  it('モバイル表示時の適切なレイアウト調整がされること', () => {
+    (useBreakpointValue as jest.Mock).mockReturnValue(true);
+    render(<OrderManagementTemplate />);
+  });
+});

--- a/src/components/templates/_tests_/PageTemplate.test.tsx
+++ b/src/components/templates/_tests_/PageTemplate.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PageTemplate } from '../PageTemplate';
+import { ChakraProvider } from '@chakra-ui/react';
+
+describe('PageTemplate コンポーネントのテスト', () => {
+  const renderWithChakra = (ui: React.ReactElement) => {
+    return render(<ChakraProvider>{ui}</ChakraProvider>);
+  };
+
+  it('子要素が正しくレンダリングされること', () => {
+    renderWithChakra(
+      <PageTemplate>
+        <p>テストコンテンツ</p>
+      </PageTemplate>,
+    );
+    expect(screen.getByText('テストコンテンツ')).toBeInTheDocument();
+  });
+
+  it('Box のプロパティが適用されていること', () => {
+    renderWithChakra(
+      <PageTemplate backgroundColor="blue.100" data-testid="page-template">
+        <p>コンテンツ</p>
+      </PageTemplate>,
+    );
+
+    const boxElement = screen.getByTestId('page-template');
+    expect(boxElement).toHaveStyle('background-color: blue.100');
+  });
+
+  it('padding のデフォルト値が適用されていること', () => {
+    renderWithChakra(
+      <PageTemplate data-testid="page-template">
+        <p>コンテンツ</p>
+      </PageTemplate>,
+    );
+
+    const boxElement = screen.getByTestId('page-template');
+
+    expect(boxElement).toHaveAttribute('class', expect.stringContaining('css'));
+  });
+});

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -24,6 +24,8 @@ export interface OrderItem {
   deleted_at: string | null;
 }
 
+export type DateRangeType = 'custom' | 'today' | 'week' | 'month';
+
 export type OrderItemField = keyof OrderFormItem;
 
 export interface FetchOrdersResponse {

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -8,4 +8,5 @@ export interface Product {
   is_active: boolean;
   created_at?: string;
   updated_at?: string;
+  deleted_at?: string | null;
 }


### PR DESCRIPTION
- OrderManagementHeaderコンポーネントを作成し、ヘッダー部分を分離
- OrderCountDisplayコンポーネントを作成し、件数表示を分離
- LoadingSpinnerコンポーネントを作成し、ローディング表示を分離
- ModalGroupコンポーネントを作成し、モーダル関連をグループ化
- 各コンポーネントの責務を明確化し、テスト容易性と再利用性を向上