### PR TITLE
注文データ取得ロジックをfetchOrdersHelperとして分離し、コードの可読性と保守性を向上

### DIFF
--- a/src/api/orderApi.ts
+++ b/src/api/orderApi.ts
@@ -1,0 +1,28 @@
+import { AppDispatch } from '@/store';
+import { fetchOrders as fetchOrdersAction } from '@/features/orders/ordersSlice';
+import type { Order } from '@/types/order';
+
+interface FetchOrdersParams {
+  page: number;
+  per_page: number;
+  search?: string;
+  status?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+interface FetchOrdersResponse {
+  data: Order[];
+  meta: { total: number };
+}
+
+export const fetchOrdersHelper = async (
+  dispatch: AppDispatch,
+  params: FetchOrdersParams,
+): Promise<FetchOrdersResponse> => {
+  const response = await dispatch(fetchOrdersAction(params)).unwrap();
+  return {
+    data: response.data.data,
+    meta: response.meta,
+  };
+};

--- a/src/hooks/useOrderManagement.ts
+++ b/src/hooks/useOrderManagement.ts
@@ -6,6 +6,7 @@ import { AppDispatch } from '@/store';
 import { fetchOrders as fetchOrdersAction } from '@/features/orders/ordersSlice';
 import { useOrderSearch } from './order/useOrderSearch';
 import { handleDateRangeFilter, handleStatusFilter } from '@/utils/filterUtils';
+import { fetchOrdersHelper } from '@/api/orderApi';
 import type {
   Order,
   OrderStatus,
@@ -170,16 +171,16 @@ export const useOrderManagement = () => {
             filterStateRef.current.currentDateRange.end.toISOString();
         }
 
-        const response = await dispatch(fetchOrdersAction(params)).unwrap();
+        const { data, meta } = await fetchOrdersHelper(dispatch, params);
 
         if (pageNum === 1) {
-          setOrders(response.data.data);
+          setOrders(data);
         } else {
-          setOrders(prev => [...prev, ...response.data.data]);
+          setOrders(prev => [...prev, ...data]);
         }
 
-        setHasMore(response.data.data.length === 15);
-        setTotalCount(response.meta.total);
+        setHasMore(data.length === 15);
+        setTotalCount(meta.total);
         setPage(pageNum);
         setStatus('succeeded');
       } catch (error) {


### PR DESCRIPTION
- fetchOrdersHelperをapi/orderApi.tsに新規作成し、API呼び出しロジックを一元化
- useOrderManagement.tsからfetchOrdersHelperを利用するようリファクタリング
- API関連ロジックを分離することで責務を明確化