### PR TITLE
LoadingSpinner コンポーネントのテストを追加

### DIFF
--- a/src/components/molecules/_tests_/LoagingSpinner.test.tsx
+++ b/src/components/molecules/_tests_/LoagingSpinner.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LoadingSpinner } from '../LoadingSpinner';
+import '@testing-library/jest-dom';
+
+describe('LoadingSpinner コンポーネント', () => {
+  test('hasMoreがfalseの場合、何も表示しない', () => {
+    render(<LoadingSpinner hasMore={false} status="loading" />);
+    const spinner = screen.queryByText('Loading...');
+    expect(spinner).not.toBeInTheDocument();
+  });
+
+  test('statusがloading以外の場合、何も表示しない', () => {
+    render(<LoadingSpinner hasMore={true} status="idle" />);
+    const spinner = screen.queryByText('Loading...');
+    expect(spinner).not.toBeInTheDocument();
+  });
+
+  test('hasMoreがtrueかつstatusがloadingの場合、Spinnerを表示する', () => {
+    render(<LoadingSpinner hasMore={true} status="loading" />);
+    const spinner = screen.getByText('Loading...');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  test('Spinnerが中央に表示される', () => {
+    const { container } = render(
+      <LoadingSpinner hasMore={true} status="loading" />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/_tests_/__snapshots__/LoagingSpinner.test.tsx.snap
+++ b/src/components/molecules/_tests_/__snapshots__/LoagingSpinner.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoadingSpinner コンポーネント Spinnerが中央に表示される 1`] = `
+<div
+  class="css-1evii0e"
+>
+  <div
+    class="chakra-spinner css-1y7joxr"
+  >
+    <span
+      class="css-8b45rq"
+    >
+      Loading...
+    </span>
+  </div>
+</div>
+`;


### PR DESCRIPTION
- hasMore が false または status が loading 以外の場合に何も表示されないことを確認
- hasMore が true かつ status が loading の場合に Spinner を表示することを確認
- スナップショットテストを追加して DOM 構造を検証