### PR TITLE
useOrderStatsフックに対する単体テストを追加

### DIFF
--- a/src/hooks/_tests_/useOrderStats.test.ts
+++ b/src/hooks/_tests_/useOrderStats.test.ts
@@ -1,0 +1,96 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useOrderStats } from '../useOrderStats';
+import {
+  useDispatch as originalUseDispatch,
+  useSelector as originalUseSelector,
+} from 'react-redux';
+import { useToast } from '@chakra-ui/react';
+import axios from 'axios';
+import {
+  setOrderStats,
+  setStatsLoading,
+  setStatsError,
+} from '@/features/orders/ordersSlice';
+
+// モック関数を型安全に設定
+const useDispatch = originalUseDispatch as unknown as jest.Mock;
+const useSelector = originalUseSelector as unknown as jest.Mock;
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('@chakra-ui/react', () => ({
+  useToast: jest.fn(),
+}));
+
+jest.mock('axios');
+
+// テストケース
+describe('useOrderStatsのテスト', () => {
+  const mockDispatch = jest.fn();
+  const mockToast = jest.fn();
+  const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // モックの初期化
+    useDispatch.mockReturnValue(mockDispatch);
+    useSelector.mockImplementation(selector =>
+      selector({
+        orders: {
+          stats: { totalCount: 100, previousCount: 80, changeRate: 25 },
+          status: 'idle',
+          error: null,
+        },
+      }),
+    );
+    (useToast as jest.Mock).mockReturnValue(mockToast);
+  });
+
+  it('初期状態でfetchInitialStatsが呼び出される', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        stats: { totalCount: 100, previousCount: 80, changeRate: 25 },
+      },
+    });
+
+    const { result } = renderHook(() => useOrderStats());
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(setStatsLoading());
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setOrderStats({ totalCount: 100, previousCount: 80, changeRate: 25 }),
+      );
+    });
+
+    expect(result.current.orderStats).toEqual({
+      totalCount: 100,
+      previousCount: 80,
+      changeRate: 25,
+    });
+  });
+
+  it('APIエラー時にエラーメッセージが表示される', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('Network Error'));
+
+    const { result } = renderHook(() => useOrderStats());
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(setStatsLoading());
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setStatsError('統計データの取得に失敗しました'),
+      );
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'エラー',
+        description: '統計データの取得中にエラーが発生しました',
+        status: 'error',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
- 初期ロード時の統計データ取得成功ケースを確認
- 統計データ取得失敗時のエラーメッセージおよびトースト表示を検証
- refetchStatsでの再取得処理をテスト