### PR TITLE
注文管理画面のコンポーネントテストを追加

### DIFF
--- a/src/app/orders/_tests_/page.test.tsx
+++ b/src/app/orders/_tests_/page.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import OrdersPage from '../page';
+import OrderManagementTemplate from '@/components/templates/OrderManagementTemplate';
+import { ProtectedPageTemplate } from '@/components/templates/ProtectedPageTemplate';
+
+jest.mock('@/components/templates/OrderManagementTemplate', () => ({
+  __esModule: true,
+  default: jest.fn(() => (
+    <div data-testid="order-management-template">Order Management Template</div>
+  )),
+}));
+
+jest.mock('@/components/templates/ProtectedPageTemplate', () => ({
+  ProtectedPageTemplate: jest.fn(({ children }) => (
+    <div data-testid="protected-page-template">{children}</div>
+  )),
+}));
+
+describe('OrdersPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('注文管理ページが正しくレンダリングされる', () => {
+    render(<OrdersPage />);
+
+    expect(screen.getByTestId('protected-page-template')).toBeInTheDocument();
+    expect(screen.getByTestId('order-management-template')).toBeInTheDocument();
+    expect(screen.getByText('Order Management Template')).toBeInTheDocument();
+  });
+
+  it('ProtectedPageTemplateが子コンポーネントをラップしている', () => {
+    render(<OrdersPage />);
+
+    const protectedTemplate = screen.getByTestId('protected-page-template');
+    const orderManagementTemplate = screen.getByTestId(
+      'order-management-template',
+    );
+
+    expect(protectedTemplate).toContainElement(orderManagementTemplate);
+  });
+
+  it('OrderManagementTemplateが正しく表示される', () => {
+    render(<OrdersPage />);
+
+    expect(OrderManagementTemplate).toHaveBeenCalled();
+  });
+
+  it('ProtectedPageTemplateが正しく表示される', () => {
+    render(<OrdersPage />);
+
+    expect(ProtectedPageTemplate).toHaveBeenCalled();
+  });
+
+  it('コンポーネントが正しい順序で入れ子になっている', () => {
+    const { container } = render(<OrdersPage />);
+
+    const protectedTemplate = screen.getByTestId('protected-page-template');
+    const orderManagementTemplate = screen.getByTestId(
+      'order-management-template',
+    );
+
+    expect(protectedTemplate.contains(orderManagementTemplate)).toBe(true);
+    expect(container.firstChild).toBe(protectedTemplate);
+  });
+});

--- a/src/utils/_tests_/filterUtils.test.ts
+++ b/src/utils/_tests_/filterUtils.test.ts
@@ -3,15 +3,12 @@ import { fetchOrders } from '@/features/orders/ordersSlice';
 import { OrderStatus, DateRange } from '@/types/order';
 import { UseToastOptions } from '@chakra-ui/react';
 import { AppDispatch } from '@/store';
-import { UnknownAction } from '@reduxjs/toolkit';
 
-// fetchOrdersのモックを作成
 jest.mock('@/features/orders/ordersSlice', () => ({
   fetchOrders: jest.fn(),
 }));
 
 describe('フィルタリング機能', () => {
-  // モックレスポンスの型定義
   interface MockResponse {
     data: {
       data: Array<{ id: number }>;
@@ -21,7 +18,6 @@ describe('フィルタリング機能', () => {
     };
   }
 
-  // モックレスポンスの作成
   const mockResponse: MockResponse = {
     data: {
       data: Array(5).fill({ id: 1 }),
@@ -31,12 +27,6 @@ describe('フィルタリング機能', () => {
     },
   };
 
-  // dispatchの返り値の型定義
-  type MockDispatchResult = {
-    unwrap: () => Promise<MockResponse>;
-  } & UnknownAction;
-
-  // モックオプションの型定義
   interface MockOptions {
     dispatch: jest.MockedFunction<AppDispatch>;
     setIsSearching: jest.Mock<void, [boolean]>;


### PR DESCRIPTION
- 保護されたページのレンダリングテストを追加
- 注文管理テンプレートの表示確認テストを追加
- コンポーネントのマウント状態のテストを追加