### PR TITLE
ダッシュボード統計コンポーネントのテストを追加

### DIFF
--- a/src/components/organisms/_tests_/DashboardStats.test.tsx
+++ b/src/components/organisms/_tests_/DashboardStats.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ChakraProvider, useToast } from '@chakra-ui/react';
+import { Provider } from 'react-redux';
+import axios from 'axios';
+import DashboardStats from '../DashboardStats';
+import { useCustomerManagement } from '@/hooks/useCustomerManagement';
+import { useWebSocket } from '@/hooks/useWebSocket';
+import { configureStore } from '@reduxjs/toolkit';
+import ordersReducer from '@/features/orders/ordersSlice';
+import statsReducer from '@/features/stats/statsSlice';
+
+jest.mock('axios');
+jest.mock('@/hooks/useCustomerManagement');
+jest.mock('@/hooks/useWebSocket');
+jest.mock('@chakra-ui/react', () => ({
+  ...jest.requireActual('@chakra-ui/react'),
+  useToast: jest.fn(() => jest.fn()),
+}));
+
+const createMockStore = () =>
+  configureStore({
+    reducer: {
+      orders: ordersReducer,
+      stats: statsReducer,
+    },
+  });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const store = createMockStore();
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <ChakraProvider>{ui}</ChakraProvider>
+      </Provider>,
+    ),
+  };
+};
+
+describe('DashboardStats', () => {
+  const mockAxiosResponse = {
+    data: {
+      stats: {
+        totalCount: 100,
+        previousCount: 90,
+        changeRate: 11.11,
+        totalSales: 1000000,
+        salesChangeRate: 15.5,
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (axios.get as jest.Mock).mockResolvedValue(mockAxiosResponse);
+    (useCustomerManagement as jest.Mock).mockReturnValue({ loading: false });
+    (useWebSocket as jest.Mock).mockReturnValue({
+      totalCount: 100,
+      changeRate: 10,
+      connectionStatus: 'connected',
+    });
+    localStorage.setItem('token', 'dummy-token');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('ローディング状態が正しく表示される', async () => {
+    (useCustomerManagement as jest.Mock).mockReturnValue({ loading: true });
+    renderWithProviders(<DashboardStats />);
+
+    await waitFor(() => {
+      const skeletons = screen.getAllByTestId('stat-card-skeleton');
+      expect(skeletons).toHaveLength(3);
+    });
+  });
+
+  it('統計データが正しく表示される', async () => {
+    renderWithProviders(<DashboardStats />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryAllByTestId('stat-card-skeleton')).toHaveLength(0);
+      },
+      { timeout: 3000 },
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('顧客数')).toBeInTheDocument();
+        expect(screen.getByText('注文数')).toBeInTheDocument();
+        expect(screen.getByText('売上高')).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it('APIエラー時にエラーメッセージが表示される', async () => {
+    const mockToast = jest.fn();
+    (useToast as jest.Mock).mockReturnValue(mockToast);
+    (axios.get as jest.Mock).mockRejectedValueOnce(new Error('API Error'));
+
+    renderWithProviders(<DashboardStats />);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'エラーが発生しました',
+        }),
+      );
+    });
+  });
+
+  it('WebSocket接続が確立されたときにデータが更新される', async () => {
+    const { rerender } = renderWithProviders(<DashboardStats />);
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('stat-card-skeleton')).toHaveLength(0);
+    });
+
+    (useWebSocket as jest.Mock).mockReturnValue({
+      totalCount: 150,
+      changeRate: 15,
+      connectionStatus: 'connected',
+    });
+
+    rerender(
+      <Provider store={createMockStore()}>
+        <ChakraProvider>
+          <DashboardStats />
+        </ChakraProvider>
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('顧客数')).toBeInTheDocument();
+    });
+  });
+
+  it('統計データの変化率が正しく表示される', async () => {
+    renderWithProviders(<DashboardStats />);
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('stat-card-skeleton')).toHaveLength(0);
+    });
+
+    await waitFor(() => {
+      const percentText = screen.getByText('10%');
+      expect(percentText).toBeInTheDocument();
+    });
+  });
+
+  it('データなしの場合でも適切に表示される', async () => {
+    (axios.get as jest.Mock).mockResolvedValue({ data: {} });
+    const mockToast = jest.fn();
+    (useToast as jest.Mock).mockReturnValue(mockToast);
+
+    renderWithProviders(<DashboardStats />);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'データの取得に失敗しました',
+          status: 'error',
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
- APIリクエスト/レスポンスのモック対応
- ローディング状態のテスト追加
- エラー状態のテスト追加
- 統計データ表示のテスト追加
- WebSocket接続の状態テスト追加