### PR TITLE
顧客情報の未登録フィールドのテストを改善

### DIFF
--- a/src/components/molecules/_tests_/CustomerBasicInfo.test.tsx
+++ b/src/components/molecules/_tests_/CustomerBasicInfo.test.tsx
@@ -1,41 +1,41 @@
-import React from "react";
-import { render, fireEvent } from "@testing-library/react";
-import "@testing-library/jest-dom";
-import CustomerBasicInfo from "../../molecules/CustomerBasicInfo";
-import { Customer } from "../../../types/customer";
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CustomerBasicInfo from '../../molecules/CustomerBasicInfo';
+import { Customer } from '../../../types/customer';
 
-describe("CustomerBasicInfo", () => {
+describe('CustomerBasicInfo', () => {
   const mockCustomer: Customer = {
-    id: "1",
-    name: "山田 太郎",
-    email: "yamada@example.com",
-    phoneNumber: "090-1234-5678",
-    address: "東京都千代田区1-2-3",
-    birthDate: "1990-01-01",
-    created_at: "2023-01-01",
-    updated_at: "2023-01-02",
+    id: '1',
+    name: '山田 太郎',
+    email: 'yamada@example.com',
+    phoneNumber: '090-1234-5678',
+    address: '東京都千代田区1-2-3',
+    birthDate: '1990-01-01',
+    created_at: '2023-01-01',
+    updated_at: '2023-01-02',
     purchaseHistory: [],
   };
 
   const newCustomer = {
-    name: "",
-    email: "",
-    phoneNumber: "",
-    address: "",
-    birthDate: "",
+    name: '',
+    email: '',
+    phoneNumber: '',
+    address: '',
+    birthDate: '',
   };
 
   const formErrors = {
-    name: "",
-    email: "",
-    phoneNumber: "",
-    address: "",
-    birthDate: "",
+    name: '',
+    email: '',
+    phoneNumber: '',
+    address: '',
+    birthDate: '',
   };
 
   const handleInputChange = jest.fn();
 
-  it("詳細モードで顧客情報が正しく表示される", () => {
+  it('詳細モードで顧客情報が正しく表示される', () => {
     const { getByText } = render(
       <CustomerBasicInfo
         customer={mockCustomer}
@@ -43,23 +43,99 @@ describe("CustomerBasicInfo", () => {
         newCustomer={newCustomer}
         formErrors={formErrors}
         handleInputChange={handleInputChange}
-      />
+      />,
     );
 
     // 顧客の各情報が表示されているかを確認
-    expect(getByText("名前:")).toBeInTheDocument();
-    expect(getByText("山田 太郎")).toBeInTheDocument();
-    expect(getByText("メールアドレス:")).toBeInTheDocument();
-    expect(getByText("yamada@example.com")).toBeInTheDocument();
-    expect(getByText("電話番号:")).toBeInTheDocument();
-    expect(getByText("090-1234-5678")).toBeInTheDocument();
-    expect(getByText("住所:")).toBeInTheDocument();
-    expect(getByText("東京都千代田区1-2-3")).toBeInTheDocument();
-    expect(getByText("生年月日:")).toBeInTheDocument();
-    expect(getByText("1990-01-01")).toBeInTheDocument();
+    expect(getByText('名前:')).toBeInTheDocument();
+    expect(getByText('山田 太郎')).toBeInTheDocument();
+    expect(getByText('メールアドレス:')).toBeInTheDocument();
+    expect(getByText('yamada@example.com')).toBeInTheDocument();
+    expect(getByText('電話番号:')).toBeInTheDocument();
+    expect(getByText('090-1234-5678')).toBeInTheDocument();
+    expect(getByText('住所:')).toBeInTheDocument();
+    expect(getByText('東京都千代田区1-2-3')).toBeInTheDocument();
+    expect(getByText('生年月日:')).toBeInTheDocument();
+    expect(getByText('1990-01-01')).toBeInTheDocument();
   });
 
-  it("編集モードでフォームが表示される", () => {
+  it('詳細モードで未登録の項目が正しく表示される', () => {
+    const customerWithEmptyFields: Customer = {
+      id: '1',
+      name: '山田 太郎',
+      email: 'yamada@example.com',
+      phoneNumber: '090-1234-5678',
+      address: '', // アドレスが空
+      birthDate: '', // 生年月日が空
+      created_at: '2023-01-01',
+      updated_at: '2023-01-02',
+      purchaseHistory: [],
+    };
+
+    const { getAllByText } = render(
+      <CustomerBasicInfo
+        customer={customerWithEmptyFields}
+        modalMode="detail"
+        newCustomer={newCustomer}
+        formErrors={formErrors}
+        handleInputChange={handleInputChange}
+      />,
+    );
+
+    // 各セクションの「未登録」テキストを確認
+    const unregisteredElements = getAllByText('未登録');
+    expect(unregisteredElements).toHaveLength(2);
+
+    // 住所セクションの確認
+    const addressSection = unregisteredElements[0].parentElement;
+    expect(addressSection).toHaveTextContent('住所:');
+    expect(addressSection).toHaveTextContent('未登録');
+
+    // 生年月日セクションの確認
+    const birthDateSection = unregisteredElements[1].parentElement;
+    expect(birthDateSection).toHaveTextContent('生年月日:');
+    expect(birthDateSection).toHaveTextContent('未登録');
+  });
+
+  it('詳細モードでnullの項目が正しく表示される', () => {
+    const customerWithNullFields: Customer = {
+      id: '1',
+      name: '山田 太郎',
+      email: 'yamada@example.com',
+      phoneNumber: '090-1234-5678',
+      address: null as unknown as string,
+      birthDate: null as unknown as string,
+      created_at: '2023-01-01',
+      updated_at: '2023-01-02',
+      purchaseHistory: [],
+    };
+
+    const { getAllByText } = render(
+      <CustomerBasicInfo
+        customer={customerWithNullFields}
+        modalMode="detail"
+        newCustomer={newCustomer}
+        formErrors={formErrors}
+        handleInputChange={handleInputChange}
+      />,
+    );
+
+    // 各セクションの「未登録」テキストを確認
+    const unregisteredElements = getAllByText('未登録');
+    expect(unregisteredElements).toHaveLength(2);
+
+    // 住所セクションの確認
+    const addressSection = unregisteredElements[0].parentElement;
+    expect(addressSection).toHaveTextContent('住所:');
+    expect(addressSection).toHaveTextContent('未登録');
+
+    // 生年月日セクションの確認
+    const birthDateSection = unregisteredElements[1].parentElement;
+    expect(birthDateSection).toHaveTextContent('生年月日:');
+    expect(birthDateSection).toHaveTextContent('未登録');
+  });
+
+  it('編集モードでフォームが表示される', () => {
     const { getByLabelText } = render(
       <CustomerBasicInfo
         customer={null}
@@ -67,18 +143,18 @@ describe("CustomerBasicInfo", () => {
         newCustomer={newCustomer}
         formErrors={formErrors}
         handleInputChange={handleInputChange}
-      />
+      />,
     );
 
     // フォームの各フィールドが表示されているかを確認
-    expect(getByLabelText("名前")).toBeInTheDocument();
-    expect(getByLabelText("メールアドレス")).toBeInTheDocument();
-    expect(getByLabelText("電話番号")).toBeInTheDocument();
-    expect(getByLabelText("住所")).toBeInTheDocument();
-    expect(getByLabelText("生年月日")).toBeInTheDocument();
+    expect(getByLabelText('名前')).toBeInTheDocument();
+    expect(getByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(getByLabelText('電話番号')).toBeInTheDocument();
+    expect(getByLabelText('住所')).toBeInTheDocument();
+    expect(getByLabelText('生年月日')).toBeInTheDocument();
   });
 
-  it("入力フィールドの変更がhandleInputChangeを呼び出す", () => {
+  it('入力フィールドの変更がhandleInputChangeを呼び出す', () => {
     const { getByLabelText } = render(
       <CustomerBasicInfo
         customer={null}
@@ -86,12 +162,12 @@ describe("CustomerBasicInfo", () => {
         newCustomer={newCustomer}
         formErrors={formErrors}
         handleInputChange={handleInputChange}
-      />
+      />,
     );
 
     // 名前フィールドを変更
-    const nameInput = getByLabelText("名前");
-    fireEvent.change(nameInput, { target: { value: "鈴木 一郎" } });
+    const nameInput = getByLabelText('名前');
+    fireEvent.change(nameInput, { target: { value: '鈴木 一郎' } });
 
     // handleInputChangeが呼び出されているか確認
     expect(handleInputChange).toHaveBeenCalled();


### PR DESCRIPTION
- getAllByText を使用して複数要素の検証を実装
- 空文字列とnull値の表示テストを追加
- 親要素コンテキストを使用した正確な検証を追加

カバレッジ改善：
- Branch Coverage: 71.42% -> 100%
- テスト対象：住所と生年月日の未登録表示（49-54行目）