### PR TITLE
test: 注文管理機能のエラーハンドリングのテストを追加

### DIFF
--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -124,7 +124,6 @@ export const fetchOrderStats = createAsyncThunk(
   },
 );
 
-// Slice
 const ordersSlice = createSlice({
   name: 'orders',
   initialState,


### PR DESCRIPTION
- fetchOrders のAxiosError時のレスポンスデータ不在パターンのテストを追加
- fetchOrderStats のAxiosError時のレスポンスデータ不在パターンのテストを追加

test: 注文管理機能の統計データ更新のテストを追加

- 統計データの初期状態からの更新テストを追加
- 既存の統計データ更新テストを追加